### PR TITLE
fix issue with optionaldata awaited when none in the telegram

### DIFF
--- a/ESP3Parser.js
+++ b/ESP3Parser.js
@@ -98,12 +98,11 @@ function ESP3() {
 		}
 		currentESP3Packet.data.fill(byte, tmp.dataOffset);
 
-		//fix error with optionaldata awaited when none is actually in the telegram
 		if(currentESP3Packet.header.optionalLength > 0) {
- 			callbackForNextByte = fillOptionalData;
- 		}else{
- 			callbackForNextByte = fetchCRC8ForDataAndCheck;
+			callbackForNextByte = fillOptionalData;
+			return;
  		}
+		callbackForNextByte = fetchCRC8ForDataAndCheck;
 	}
 
 	/**

--- a/ESP3Parser.js
+++ b/ESP3Parser.js
@@ -97,7 +97,13 @@ function ESP3() {
 			return;
 		}
 		currentESP3Packet.data.fill(byte, tmp.dataOffset);
-		callbackForNextByte = fillOptionalData;
+
+		//fix error with optionaldata awaited when none is actually in the telegram
+		if(currentESP3Packet.header.optionalLength > 0) {
+ 			callbackForNextByte = fillOptionalData;
+ 		}else{
+ 			callbackForNextByte = fetchCRC8ForDataAndCheck;
+ 		}
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the machine state improper state when an EnOcean packet is received with header.optionalLength = 0

in this case, fillOptionalData was called and pushed the byte into its array. This byte was actually the final data+optional data crc. Hence, "locking" the data into awaiting the crc. It would then require to receive a frame from an EnOcean compatible device to "flush" (and lose) the buffer.

The proposed PR fixes it by branching into the correct step when dealing with optional data