### PR TITLE
Packet factory

### DIFF
--- a/ESP3/buffer2struct.js
+++ b/ESP3/buffer2struct.js
@@ -1,0 +1,16 @@
+module.exports = function (buf) {
+  var dl = parseInt(buf.slice(1, 3).toString('hex'), 16)
+  var odl = buf[3]
+  return {
+    syncByte: 0x55,
+    header: {
+      dataLength: dl,
+      optionalLength: odl,
+      packetType: buf[4]
+    },
+    crc8Header: buf[5],
+    data: buf.slice(6, 6 + dl),
+    optionalData: buf.slice(6, 6 + dl + odl),
+    crc8Data: buf[6 + dl + odl]
+  }
+}

--- a/Packet.js
+++ b/Packet.js
@@ -1,3 +1,19 @@
+const buffer2struct = require('./ESP3/buffer2struct.js')
+const packetPrototypes = {
+  0: require('./ESP3/ESP3Packet.js'),
+  1: require('./ESP3/PacketTypes/RadioERP1.js'),
+  2: require('./ESP3/PacketTypes/Response'),
+  3: require('./ESP3/PacketTypes/RadioSubTel'),
+  4: require('./ESP3/PacketTypes/Event'),
+  5: require('./ESP3/PacketTypes/CommonCommand'),
+  6: require('./ESP3/PacketTypes/SmartAckCommand'),
+  7: require('./ESP3/PacketTypes/RemoteManCommand'),
+  9: require('./ESP3/PacketTypes/RadioMessage'),
+  0xa: require('./ESP3/PacketTypes/RadioERP2'),
+  0x10: require('./ESP3/PacketTypes/Radio802'),
+  0x11: require('./ESP3/PacketTypes/Command24')
+}
+
 module.exports = {
   'ESP3Packet': require('./ESP3/ESP3Packet.js'),
   'RadioERP1': require('./ESP3/PacketTypes/RadioERP1.js'),
@@ -10,5 +26,23 @@ module.exports = {
   'RadioMessage': require('./ESP3/PacketTypes/RadioMessage'),
   'RadioERP2': require('./ESP3/PacketTypes/RadioERP2'),
   'Radio802': require('./ESP3/PacketTypes/Radio802'),
-  'Command24': require('./ESP3/PacketTypes/Command24')
+  'Command24': require('./ESP3/PacketTypes/Command24'),
+  from: function (input) {
+    if (input instanceof packetPrototypes[0]) {
+      return new packetPrototypes[input.header.packetType](input)
+    }
+    if (input instanceof Buffer) {
+      var struct = buffer2struct(input)
+      return new packetPrototypes[struct.header.packetType](struct)
+    }
+    if (typeof input === 'string') {
+      struct = buffer2struct(Buffer.from(input, 'hex'))
+      return new packetPrototypes[struct.header.packetType](struct)
+    }
+    if (input.header && input.header.packetType) {
+      return new packetPrototypes[input.header.packetType](input)
+    } else {
+      throw new Error('invalid packet descriptor')
+    }
+  }
 }

--- a/Packet.js
+++ b/Packet.js
@@ -15,18 +15,18 @@ const packetPrototypes = {
 }
 
 module.exports = {
-  'ESP3Packet': require('./ESP3/ESP3Packet.js'),
-  'RadioERP1': require('./ESP3/PacketTypes/RadioERP1.js'),
-  'Response': require('./ESP3/PacketTypes/Response'),
-  'RadioSubTel': require('./ESP3/PacketTypes/RadioSubTel'),
-  'Event': require('./ESP3/PacketTypes/Event'),
-  'CommonCommand': require('./ESP3/PacketTypes/CommonCommand'),
-  'SmartAckCommand': require('./ESP3/PacketTypes/SmartAckCommand'),
-  'RemoteManCommand': require('./ESP3/PacketTypes/RemoteManCommand'),
-  'RadioMessage': require('./ESP3/PacketTypes/RadioMessage'),
-  'RadioERP2': require('./ESP3/PacketTypes/RadioERP2'),
-  'Radio802': require('./ESP3/PacketTypes/Radio802'),
-  'Command24': require('./ESP3/PacketTypes/Command24'),
+  'ESP3Packet': packetPrototypes[0],
+  'RadioERP1': packetPrototypes[1]),
+  'Response': packetPrototypes[2],
+  'RadioSubTel': packetPrototypes[3],
+  'Event': packetPrototypes[4],
+  'CommonCommand': packetPrototypes[5],
+  'SmartAckCommand': packetPrototypes[6],
+  'RemoteManCommand': packetPrototypes[7],
+  'RadioMessage': packetPrototypes[9],
+  'RadioERP2': packetPrototypes[10],
+  'Radio802': packetPrototypes[16],
+  'Command24': packetPrototypes[17],
   from: function (input) {
     if (input instanceof packetPrototypes[0]) {
       return new packetPrototypes[input.header.packetType](input)

--- a/Packet.js
+++ b/Packet.js
@@ -16,7 +16,7 @@ const packetPrototypes = {
 
 module.exports = {
   'ESP3Packet': packetPrototypes[0],
-  'RadioERP1': packetPrototypes[1]),
+  'RadioERP1': packetPrototypes[1],
   'Response': packetPrototypes[2],
   'RadioSubTel': packetPrototypes[3],
   'Event': packetPrototypes[4],

--- a/test/Factory.test.js
+++ b/test/Factory.test.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-undef  */
+const Packet = require('../Packet.js')
+const assert = require('assert')
+describe('Concrete Packets', function () {
+  it('SHOULD be creatable from generic ESP3packets', function () {
+    var esp3packet = new Packet.ESP3Packet({
+      syncByte: 0x55,
+      header: {
+        dataLength: 1,
+        optionalLength: 0,
+        packetType: 5
+      },
+      crc8Header: 0x70,
+      data: Buffer.from('08', 'hex'),
+      optionalData: Buffer.alloc(0),
+      crc8Data: 0x38
+    })
+    var newPacket = Packet.from(esp3packet)
+    assert(newPacket instanceof Packet.CommonCommand, true)
+    assert(newPacket.getRawBuffer().toString('hex'), '5500010005700838')
+  })
+  it('SHOULD be creatable from raw Buffers', function () {
+    var newPacket = Packet.from(Buffer.from('5500010005700838', 'hex'))
+    assert(newPacket instanceof Packet.CommonCommand, true)
+    assert(newPacket.getRawBuffer().toString('hex'), '5500010005700838')
+  })
+  it('SHOULD be creatable from strings', function () {
+    var newPacket = Packet.from('5500010005700838')
+    assert(newPacket instanceof Packet.CommonCommand, true)
+    assert(newPacket.getRawBuffer().toString('hex'), '5500010005700838')
+  })
+  it('SHOULD be creatable from ESP3PacketStructs', function () {
+    var newPacket = Packet.from({
+      syncByte: 0x55,
+      header: {
+        dataLength: 1,
+        optionalLength: 0,
+        packetType: 5
+      },
+      crc8Header: 0x70,
+      data: Buffer.from('08', 'hex'),
+      optionalData: Buffer.alloc(0),
+      crc8Data: 0x38
+    })
+    assert(newPacket instanceof Packet.CommonCommand, true)
+    assert(newPacket.getRawBuffer().toString('hex'), '5500010005700838')
+  })
+  it('created from invalid packet descriptors SHOULD throw', function () {
+    function x () {
+      Packet.from({ foo: 'bar' })
+    }
+    function y () {
+      Packet.from({ foo: 'bar' })
+    }
+    assert.throws(x, Error)
+    assert.throws(y, Error)
+  })
+})

--- a/test/Helper.test.js
+++ b/test/Helper.test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-undef  */
+const buffer2struct = require('../ESP3/buffer2struct.js')
+const assert = require('assert')
+describe('The Helper Function', function () {
+  describe('buffer2struct', function () {
+    it('SHOULD return filled packet structs from raw buffers', function () {
+      var struct = buffer2struct(Buffer.from('55000a0701eba5c87f710fffdba5e40001ffffffff47000d', 'hex'))
+      assert(struct.syncByte, 0x55)
+      assert(struct.header.dataLength, 0x0a)
+      assert(struct.header.optionalLength, 0x07)
+      assert(struct.header.packetType, 0x01)
+      assert(struct.crc8Header, 0xeb)
+      assert(struct.data.toString('hex'), 'a5c87f710fffdba5e400')
+      assert(struct.optionalData.toString('hex'), '01ffffffff4700')
+      assert(struct.crc8Data, 0x0d)
+    })
+  })
+})


### PR DESCRIPTION
implementation of a packet-factory 

    const Packet = require("./Packet.js")
    Packet.from(...)

packet.from expects and ESP3Packet, a raw buffer, a string or a struct with at least `{ header:{ packetType:x } }`

maybe we can add `Packet.from(number)` where number is a valid packetType